### PR TITLE
Improve Loader

### DIFF
--- a/content/mu-plugins/loader.php
+++ b/content/mu-plugins/loader.php
@@ -22,6 +22,6 @@ $global_mu_plugins = [
 // Load the plugin files, if they exist.
 foreach ( $global_mu_plugins as $file ) {
 	if ( is_readable( WPMU_PLUGIN_DIR . '/' . $file ) ) {
-		require_once WPMU_PLUGIN_DIR . '/' . $file;
+		include_once WPMU_PLUGIN_DIR . '/' . $file;
 	}
 }

--- a/content/mu-plugins/loader.php
+++ b/content/mu-plugins/loader.php
@@ -6,7 +6,7 @@
  * Author URI:  https://humanmade.com/
  * Version:     1.0
  *
- * @package siemens-milestones
+ * @package block-playground
  */
 
 if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
@@ -21,7 +21,7 @@ $global_mu_plugins = [
 
 // Load the plugin files, if they exist.
 foreach ( $global_mu_plugins as $file ) {
-	if ( file_exists( WPMU_PLUGIN_DIR . '/' . $file ) ) {
+	if ( is_readable( WPMU_PLUGIN_DIR . '/' . $file ) ) {
 		require_once WPMU_PLUGIN_DIR . '/' . $file;
 	}
 }


### PR DESCRIPTION
This PR includes improvements to the `loader.php` file:

* Fix the package name.
* Use `is_readable()` instead of `file_exists()`.  
The file could exist and still not be readable.  
Also, most of the time, you don't need `file_exists`at all, because you rather need to check read/write permissions.
* Use the `include_once` PHP language construct instead of `require_once`.  
This is mainly becausewe already checked if the file is there, so, given it is readable, see previous item, it will never fail anyway.  
Also, see the [PEAR `IncludingFileSniff` PHP_CodeSniffer sniff](https://github.com/squizlabs/PHP_CodeSniffer/blob/957a2b63c084cc8b34cdb1a2c77ae12257c79a3d/src/Standards/PEAR/Sniffs/Files/IncludingFileSniff.php#L97-L130).